### PR TITLE
update mapbox-gl-js 0.44.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
   <link type="text/css" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
   <link href="https://fonts.googleapis.com/css?family=Kanit|Ubuntu+Mono" rel="stylesheet">
   <link type="text/css" rel="stylesheet" href="style.css" />
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.41.0/mapbox-gl.js'></script>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.41.0/mapbox-gl.css' rel='stylesheet' />
+  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.1/mapbox-gl.js'></script>
+  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.44.1/mapbox-gl.css' rel='stylesheet' />
 </head>
 
 <body>


### PR DESCRIPTION
Hello! This updates to the latest mapbox-gl-js version to stop the Chrome webgl flickering bug. https://github.com/mapbox/mapbox-gl-js/issues/5490

cc @akadouri 